### PR TITLE
Prepare for Uint8List SDK breaking change

### DIFF
--- a/lib/src/api_call.dart
+++ b/lib/src/api_call.dart
@@ -158,7 +158,7 @@ class ApiBroker<AC extends ApiOpt> {
 
       // Process the response.
       if (response.statusCode == HttpStatus.ok) {
-        var jsonX = await response.transform(utf8.decoder).join();
+        var jsonX = await utf8.decoder.bind(response).join();
 
         /// https://api.dartlang.org/stable/2.1.0/dart-convert/dart-convert-library.html
         var data = json.decode(jsonX);

--- a/test/http_client_test.dart
+++ b/test/http_client_test.dart
@@ -17,7 +17,7 @@ void test1() async {
   var response = await request.close(); // sends the request
 
   // transforms and prints the response
-  await for (var contents in response.transform(const Utf8Decoder())) {
+  await for (var contents in const Utf8Decoder().bind(response)) {
     print('test1 result:');
     print(contents);
   }
@@ -32,8 +32,8 @@ void main() async {
     await HttpClient()
         .getUrl(Uri.parse('https://swapi.co/api/people/1'))
         .then((request) => request.close()) // sends the request
-        .then((response) => response
-        .transform(const Utf8Decoder())
+        .then((response) => const Utf8Decoder()
+            .bind(response)
             .listen(print)); // transforms and prints the response
 
     print('2');


### PR DESCRIPTION
A recent change to the Dart SDK updated `HttpClientResponse`
to implement `Stream<Uint8List>` rather than implementing
`Stream<List<int>>`.

This forwards-compatible change updates calls to
`Stream.transform(StreamTransformer)` to instead call the
functionally equivalent `StreamTransformer.bind(Stream)`
API, which puts the stream in a covariant position and
thus causes the SDK change to be non-breaking.

https://github.com/dart-lang/sdk/issues/36900
